### PR TITLE
Fix mixed content build error

### DIFF
--- a/content/blog/2015-03-30-community-roundup-26.md
+++ b/content/blog/2015-03-30-community-roundup-26.md
@@ -29,7 +29,7 @@ Colin also [blogged about his experience using React Native](http://blog.scottlo
 
 Spencer Ahrens and I had the great pleasure to talk about React Native on [The Changelog](https://thechangelog.com/149/) podcast. It was really fun to chat for an hour, I hope that you'll enjoy listening to it. :)
 
-<audio src="http://fdlyr.co/d/changelog/cdn.5by5.tv/audio/broadcasts/changelog/2015/changelog-149.mp3" controls="controls" style="width: 100%"></audio>
+<audio src="https://fdlyr.co/d/changelog/cdn.5by5.tv/audio/broadcasts/changelog/2015/changelog-149.mp3" controls="controls" style="width: 100%"></audio>
 
 
 ## Hacker News {#hacker-news}


### PR DESCRIPTION
Netlify builds fail because of mixed content error in this audio link. The link destination is broken anyways and the Chinese translation team has also fixed it this way (they also run Netlify) https://github.com/reactjs/zh-hans.reactjs.org/commit/afd94503e84bd512982aa359341b702b268031a7.